### PR TITLE
Remove stack/machine definition from bitrise.yml file

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,10 +9,6 @@ trigger_map:
 - pull_request_source_branch: '*'
   workflow: primary
 
-meta:
-  bitrise.io:
-    stack: osx-xcode-13.4.x
-    machine_type_id: g2.4core
 app:
   envs:
   - BITRISE_PROJECT_PATH: Bitrise-iOS-Cocoapods-Sample.xcworkspace


### PR DESCRIPTION
The stack and machine are overridden during the process of creating the sample app during onboarding, so there's no need to define them in the file within the repo. This may change later if we determine there's value in having it in the file, even though it's overridden.